### PR TITLE
FIX Update getInstallerVersion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2.4.2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@3eda58347216592f618bb1dff277810b6698e4ca # v2.19.1
+        with:
+          php-version: 8.1
+          extensions: yaml
+
+      - name: Install PHPUnit
+        run: wget https://phar.phpunit.de/phpunit-9.5.phar
+
+      - name: PHPUnit
+        run: php phpunit-9.5.phar --verbose --colors=always

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.phpunit.result.cache

--- a/action.php
+++ b/action.php
@@ -4,10 +4,6 @@ include 'consts.php';
 include 'job_creator.php';
 
 // Reads inputs.yml and creates a new json matrix
-$inputs = yaml_parse(file_get_contents('__inputs.yml'));
-if ($inputs === false) {
-    echo 'Unable to parse __inputs.yml';
-    exit(1);
-}
+$yml = file_get_contents('__inputs.yml');
 $jobCreator = new JobCreator();
-echo $jobCreator->createJson($inputs);
+echo $jobCreator->createJson($yml);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class JobCreatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideGetInstallerVersion
+     */
+    public function testGetInstallerVersion(
+        string $githubRepository,
+        string $branch,
+        string $expected
+    ): void {
+        $creator = new JobCreator();
+        $actual = $creator->getInstallerVersion($githubRepository, $branch);
+        $this->assertSame($expected, $actual);
+    }
+
+    private function getLatestInstallerVersion(): string
+    {
+        $versions = array_keys(INSTALLER_TO_PHP_VERSIONS);
+        natsort($versions);
+        $versions = array_reverse($versions);
+        return $versions[0];
+    }
+
+    public function provideGetInstallerVersion(): array
+    {
+        $latest = $this->getLatestInstallerVersion() . '.x-dev';
+        return [
+            // no-installer repo
+            ['myaccount/recipe-cms', '4', ''],
+            ['myaccount/recipe-cms', '4.10', ''],
+            ['myaccount/recipe-cms', 'burger', ''],
+            ['myaccount/recipe-cms', 'pulls/4/myfeature', ''],
+            ['myaccount/recipe-cms', 'pulls/4.10/myfeature', ''],
+            ['myaccount/recipe-cms', 'pulls/burger/myfeature', ''],
+            ['myaccount/recipe-cms', '4-release', ''],
+            ['myaccount/recipe-cms', '4.10-release', ''],
+            // lockstepped repo with 4.* naming
+            ['myaccount/silverstripe-framework', '4', '4.x-dev'],
+            ['myaccount/silverstripe-framework', '4.10', '4.10.x-dev'],
+            ['myaccount/silverstripe-framework', 'burger', $latest],
+            ['myaccount/silverstripe-framework', 'pulls/4/mybugfix', '4.x-dev'],
+            ['myaccount/silverstripe-framework', 'pulls/4.10/mybugfix', '4.10.x-dev'],
+            ['myaccount/silverstripe-framework', 'pulls/burger/myfeature', $latest],
+            ['myaccount/silverstripe-framework', '4-release', '4.x-dev'],
+            ['myaccount/silverstripe-framework', '4.10-release', '4.10.x-dev'],
+            // lockstepped repo with 1.* naming
+            ['myaccount/silverstripe-admin', '1', '4.x-dev'],
+            ['myaccount/silverstripe-admin', '1.10', '4.10.x-dev'],
+            ['myaccount/silverstripe-admin', 'burger', $latest],
+            ['myaccount/silverstripe-admin', 'pulls/1/mybugfix', '4.x-dev'],
+            ['myaccount/silverstripe-admin', 'pulls/1.10/mybugfix', '4.10.x-dev'],
+            ['myaccount/silverstripe-admin', 'pulls/burger/myfeature', $latest],
+            ['myaccount/silverstripe-admin', '1-release', '4.x-dev'],
+            ['myaccount/silverstripe-admin', '1.10-release', '4.10.x-dev'],
+            // non-lockedstepped repo
+            ['myaccount/silverstripe-tagfield', '2', $latest],
+            ['myaccount/silverstripe-tagfield', '2.9', $latest],
+            ['myaccount/silverstripe-tagfield', 'burger', $latest],
+            ['myaccount/silverstripe-tagfield', 'pulls/2/mybugfix', $latest],
+            ['myaccount/silverstripe-tagfield', 'pulls/2.9/mybugfix', $latest],
+            ['myaccount/silverstripe-tagfield', 'pulls/burger/myfeature', $latest],
+            ['myaccount/silverstripe-tagfield', '2-release', $latest],
+            ['myaccount/silverstripe-tagfield', '2.9-release', $latest],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetInputsValid
+     */
+    public function testGetInputsValid(string $yml, array $expected)
+    {
+        if (!function_exists('yaml_parse')) {
+            $this->markTestSkipped('yaml extension is not installed');
+        }
+        $creator = new JobCreator();
+        $actual = $creator->getInputs($yml);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function provideGetInputsValid(): array
+    {
+        return [
+            [
+                <<<EOT
+                endtoend: true
+                js: true
+                phpcoverage: false
+                phpcoverage_force_off: false
+                phplinting: true
+                phpunit: true
+                simple_matrix: false
+                github_repository: 'myaccount/silverstripe-versioned'
+                github_my_ref: 'pulls/1.10/module-standards'
+                EOT,
+                [
+                    'endtoend' => true,
+                    'js' => true,
+                    'phpcoverage' => false,
+                    'phpcoverage_force_off' => false,
+                    'phplinting' => true,
+                    'phpunit' => true,
+                    'simple_matrix' => false,
+                    'github_repository' => 'myaccount/silverstripe-versioned',
+                    'github_my_ref'=> 'pulls/1.10/module-standards'
+                ]
+            ],
+        ];
+    }
+
+     /**
+     * @dataProvider provideGetInputsInvalid
+     */
+    public function testGetInputsInvalid(string $yml, string $expectedMessage)
+    {
+        if (!function_exists('yaml_parse')) {
+            $this->markTestSkipped('yaml extension is not installed');
+        }
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage($expectedMessage);
+        $creator = new JobCreator();
+        $creator->getInputs($yml);
+    }
+
+    public function provideGetInputsInvalid(): array
+    {
+        return [
+            // missing quotes around github_my_ref (would turn into an int, so 1.10 becomes 1.1)
+            [
+                <<<EOT
+                github_my_ref: 1.10
+                EOT,
+                'github_my_ref needs to be surrounded by single-quotes'
+            ],
+            // invalid yml
+            [
+                <<<EOT
+                this: --
+                    is: - total: ' nonsense
+                    "
+                EOT,
+                'Failed to parse yml'
+            ],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+// working directory will be root
+include 'consts.php';
+include 'job_creator.php';


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Updating the logic in `getInstallerVersion()` so that the correct version is returned

[Example failure](https://github.com/creative-commoners/silverstripe-versioned/runs/7124625062?check_suite_focus=true#step:2:532)

`PHP Warning:  Undefined array key "4.10/module-standards" in /home/runner/work/_actions/silverstripe/gha-generate-matrix/v1/job_creator.php on line 39`


Also a slight refactor to allow adding unit tests for the yaml parsing