### PR TITLE
FIX Exclude recipe-plugin from requiring installer

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -72,8 +72,8 @@ const NO_INSTALLER_LOCKSTEPPED_REPOS = [
 ];
 
 const NO_INSTALLER_UNLOCKSTEPPED_REPOS = [
-    // vendor-plugin is not a recipe, though we also do not want installer
-    'vendor-plugin'
+    'vendor-plugin',
+    'recipe-plugin',
 ];
 
 const CMS_TO_REPO_MAJOR_VERSIONS = [


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Fixes
```
PHP Fatal error:  Uncaught Error: Class 'Page' not found in /home/runner/work/recipe-plugin/recipe-plugin/vendor/silverstripe/errorpage/src/ErrorPage.php:39
```
https://github.com/creative-commoners/recipe-plugin/runs/7191506616?check_suite_focus=true