### PR TITLE
FIX Hardcode some module versions to installer version

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -106,3 +106,13 @@ const CMS_TO_REPO_MAJOR_VERSIONS = [
         'silverstripe-installer' => '5',
     ],
 ];
+
+const INSTALLER_TO_REPO_MINOR_VERSIONS = [
+    '4.10' => [
+        'html5' => '2.3',
+        'silverstripe-elemental-bannerblock' => '2.4',
+        'silverstripe-session-manager' => '1.2',
+        'silverstripe-userforms' => '5.12',
+        'silverstripe-totp-authenticator' => '4.3',
+    ]
+];

--- a/job_creator.php
+++ b/job_creator.php
@@ -32,6 +32,14 @@ class JobCreator
                 return $cmsMajor . '.' . $portions[1] . '.x-dev';
             }
         }
+        // hardcoded installer version for repo version
+        foreach (array_keys(INSTALLER_TO_REPO_MINOR_VERSIONS) as $installerVersion) {
+            foreach (INSTALLER_TO_REPO_MINOR_VERSIONS[$installerVersion] as $_repo => $repoVersion) {
+                if ($repo === $_repo && $repoVersion === $branch) {
+                    return $installerVersion . '.x-dev';
+                }
+            }
+        }
         // fallback to use the latest minor version of installer
         $installerVersions = array_keys(INSTALLER_TO_PHP_VERSIONS);
         $installerVersions = array_filter($installerVersions, fn($version) => substr($version, 0, 1) === $cmsMajor);

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -126,6 +126,10 @@ class JobCreatorTest extends TestCase
             ['myaccount/silverstripe-tagfield', 'pulls/burger/myfeature', $latest],
             ['myaccount/silverstripe-tagfield', '2-release', $latest],
             ['myaccount/silverstripe-tagfield', '2.9-release', $latest],
+            // hardcoded repo version
+            ['myaccount/silverstripe-session-manager', '1', $latest],
+            ['myaccount/silverstripe-session-manager', '1.2', '4.10.x-dev'],
+            ['myaccount/silverstripe-session-manager', 'burger', $latest],
         ];
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Also moving the 'use parent branch' logic to a more logic place since it's supposed to be used as a fallback