### PR TITLE
ENH Require graphql3 for the first endtoend test

### DIFF
--- a/job_creator.php
+++ b/job_creator.php
@@ -344,9 +344,11 @@ class JobCreator
         }
         // endtoend / behat
         if ($run['endtoend'] && file_exists('behat.yml')) {
+            $graphql3 = !$simpleMatrix && $this->getCmsMajorFromBranch() == '4';
             $job = $this->createJob(0, [
                 'endtoend' => true,
-                'endtoend_suite' => 'root'
+                'endtoend_suite' => 'root',
+                'composer_require_extra' => $graphql3 ? 'silverstripe/graphql:^3' : ''
             ]);
             // use minimum version of 7.4 for endtoend because was having apt dependency issues
             // in CI when using php 7.3:


### PR DESCRIPTION
There are 2 endtoend tests created - ensure the first of these gets graphql3, similar to what travis used to do

If running simple_matrix, only a single endtoend job is created, there use graphql4