### PR TITLE
FIX Don't install installer for api repo CI

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -77,6 +77,7 @@ const NO_INSTALLER_LOCKSTEPPED_REPOS = [
 const NO_INSTALLER_UNLOCKSTEPPED_REPOS = [
     'vendor-plugin',
     'recipe-plugin',
+    'api.silverstripe.org',
 ];
 
 const CMS_TO_REPO_MAJOR_VERSIONS = [


### PR DESCRIPTION
Allows https://github.com/silverstripe/api.silverstripe.org to use gha-ci for its unit tests