### PR TITLE
ENH Remove pgsql as default job

### DIFF
--- a/job_creator.php
+++ b/job_creator.php
@@ -312,16 +312,11 @@ class JobCreator
                 'phpunit' => true,
                 'phpunit_suite' => $suite,
             ]);
-            $matrix['include'][] = $this->createJob(1, [
-                'db' => DB_PGSQL,
-                'phpunit' => true,
-                'phpunit_suite' => $suite,
-            ]);
             // this same mysql pdo test is also created for the phpcoverage job, so only add it here if
             // not creating a phpcoverage job.
             // note: phpcoverage also runs unit tests
             if ($this->getCmsMajor() === '4' && !$this->doRunPhpCoverage($run)) {
-                $matrix['include'][] = $this->createJob(2, [
+                $matrix['include'][] = $this->createJob(1, [
                     'db' => DB_MYSQL_57_PDO,
                     'phpunit' => true,
                     'phpunit_suite' => $suite,

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -191,23 +191,6 @@ class JobCreatorTest extends TestCase
                     [
                         'installer_version' => '4.11.x-dev',
                         'php' => '8.0',
-                        'db' => DB_PGSQL,
-                        'composer_require_extra' => '',
-                        'composer_args' => '',
-                        'name_suffix' => '',
-                        'phpunit' => 'true',
-                        'phpunit_suite' => 'all',
-                        'phplinting' => 'false',
-                        'phpcoverage' => 'false',
-                        'endtoend' => 'false',
-                        'endtoend_suite' => 'root',
-                        'endtoend_config' => '',
-                        'js' => 'false',
-                        'name' => '8.0 pgsql phpunit all',
-                    ],
-                    [
-                        'installer_version' => '4.11.x-dev',
-                        'php' => '8.1',
                         'db' => DB_MYSQL_57_PDO,
                         'composer_require_extra' => '',
                         'composer_args' => '',
@@ -220,7 +203,7 @@ class JobCreatorTest extends TestCase
                         'endtoend_suite' => 'root',
                         'endtoend_config' => '',
                         'js' => 'false',
-                        'name' => '8.1 mysql57pdo phpunit all',
+                        'name' => '8.0 mysql57pdo phpunit all',
                     ],
                     [
                         'installer_version' => '4.11.x-dev',
@@ -268,23 +251,6 @@ class JobCreatorTest extends TestCase
                         'endtoend_config' => '',
                         'js' => 'false',
                         'name' => '8.1 prf-low mysql57 phpunit all',
-                    ],
-                    [
-                        'installer_version' => '5.x-dev',
-                        'php' => '8.1',
-                        'db' => DB_PGSQL,
-                        'composer_require_extra' => '',
-                        'composer_args' => '',
-                        'name_suffix' => '',
-                        'phpunit' => 'true',
-                        'phpunit_suite' => 'all',
-                        'phplinting' => 'false',
-                        'phpcoverage' => 'false',
-                        'endtoend' => 'false',
-                        'endtoend_suite' => 'root',
-                        'endtoend_config' => '',
-                        'js' => 'false',
-                        'name' => '8.1 pgsql phpunit all',
                     ],
                     [
                         'installer_version' => '5.x-dev',
@@ -549,9 +515,9 @@ class JobCreatorTest extends TestCase
     public function provideDynamicMatrix(): array
     {
         return [
-            ['true', 4],
+            ['true', 3],
             ['false', 0],
-            ['', 4],
+            ['', 3],
         ];
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/601

- I've also updated the PDO job to run in PHP 8.0 instead of PHP 8.1
- Previously the PGSQL job ran PHP 8.0
- The MYSQL 8 job continues to run PHP 8.1

Author to tag 1.4.0 post-merge
