### PR TITLE
FIX Add missing repo from hardcoded consts

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -328,5 +328,6 @@ const INSTALLER_TO_REPO_MINOR_VERSIONS = [
         'silverstripe-versionfeed' => '2.3',
         'silverstripe-webauthn-authenticator' => '4.6',
         'silverstripe-widgets' => '2.3',
+        'silverstripe-gridfieldextensions' => '3.5',
     ],
 ];

--- a/hardcoded.php
+++ b/hardcoded.php
@@ -50,3 +50,12 @@ ksort($versions);
 foreach ($versions as $repoName => $version) {
     echo "        '$repoName' => '$version',\n";
 }
+
+// Find any repositories which were in the previous version that aren't in this one
+$missing = array_diff(array_keys(INSTALLER_TO_REPO_MINOR_VERSIONS[array_key_last(INSTALLER_TO_REPO_MINOR_VERSIONS)]), array_keys($versions));
+if (!empty($missing)) {
+    $formatColor = "\033[31m";
+    $endFormat = "\033[0m";
+    echo "\n" . $formatColor . 'Warning: The following modules were in the last release in INSTALLER_TO_REPO_MINOR_VERSIONS but are missing from .cow.pat.json:' . $endFormat . "\n";
+    echo implode("\n", $missing) . "\n";
+}


### PR DESCRIPTION
This repo was missing in https://github.com/silverstripe/gha-generate-matrix/pull/36 because it's not in the cowpat.

I've also added a commit here which will help avoid similar mistakes in the future by calling out if repositories are missing which were present in the previous release.

## IMPORTANT
The person who merges this should tag a new patch version immediately afterward

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/606