### PR TITLE
FIX Disable prefer-lowest job in CMS 5

### DIFF
--- a/job_creator.php
+++ b/job_creator.php
@@ -327,11 +327,14 @@ class JobCreator
                 'phpunit_suite' => $suite,
             ]);
         } else {
-            $matrix['include'][] = $this->createJob(0, [
-                'composer_args' => '--prefer-lowest',
-                'phpunit' => true,
-                'phpunit_suite' => $suite,
-            ]);
+            // disabling --prefer-lowest build in CMS 5 until 5.0.0 stable is released
+            if ($this->getCmsMajor() === '4') {
+                $matrix['include'][] = $this->createJob(0, [
+                    'composer_args' => '--prefer-lowest',
+                    'phpunit' => true,
+                    'phpunit_suite' => $suite,
+                ]);
+            }
             // this same mysql pdo test is also created for the phpcoverage job, so only add it here if
             // not creating a phpcoverage job.
             // note: phpcoverage also runs unit tests

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -244,23 +244,23 @@ class JobCreatorTest extends TestCase
                     EOT
                 ]),
                 [
-                    [
-                        'installer_version' => '5.x-dev',
-                        'php' => '8.1',
-                        'db' => DB_MYSQL_57,
-                        'composer_require_extra' => '',
-                        'composer_args' => '--prefer-lowest',
-                        'name_suffix' => '',
-                        'phpunit' => 'true',
-                        'phpunit_suite' => 'all',
-                        'phplinting' => 'false',
-                        'phpcoverage' => 'false',
-                        'endtoend' => 'false',
-                        'endtoend_suite' => 'root',
-                        'endtoend_config' => '',
-                        'js' => 'false',
-                        'name' => '8.1 prf-low mysql57 phpunit all',
-                    ],
+                    // [
+                    //     'installer_version' => '5.x-dev',
+                    //     'php' => '8.1',
+                    //     'db' => DB_MYSQL_57,
+                    //     'composer_require_extra' => '',
+                    //     'composer_args' => '--prefer-lowest',
+                    //     'name_suffix' => '',
+                    //     'phpunit' => 'true',
+                    //     'phpunit_suite' => 'all',
+                    //     'phplinting' => 'false',
+                    //     'phpcoverage' => 'false',
+                    //     'endtoend' => 'false',
+                    //     'endtoend_suite' => 'root',
+                    //     'endtoend_config' => '',
+                    //     'js' => 'false',
+                    //     'name' => '8.1 prf-low mysql57 phpunit all',
+                    // ],
                     [
                         'installer_version' => '5.x-dev',
                         'php' => '8.1',
@@ -752,7 +752,7 @@ class JobCreatorTest extends TestCase
                 '',
                 '5.x-dev',
                 [
-                    '8.1 prf-low mysql57 phpunit all',
+                    // '8.1 prf-low mysql57 phpunit all',
                     '8.1 mysql80 phpunit all'
                 ]
             ],
@@ -761,7 +761,7 @@ class JobCreatorTest extends TestCase
                 '21.99',
                 '5.x-dev',
                 [
-                    '8.1 prf-low mysql57 phpunit all',
+                    // '8.1 prf-low mysql57 phpunit all',
                     '8.1 mysql80 phpunit all'
                 ]
             ],
@@ -770,7 +770,7 @@ class JobCreatorTest extends TestCase
                 'fish',
                 '5.x-dev',
                 [
-                    '8.1 prf-low mysql57 phpunit all',
+                    // '8.1 prf-low mysql57 phpunit all',
                     '8.1 mysql80 phpunit all'
                 ]
             ],


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/657

Since it's a temporary disabling of the prefer-lowest tests, I've commented out the relevant bits of unit tests so that it's easy to re-enable them later

