### PR TITLE
DEP Update dependencies to avoid deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2.4.2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Install PHP
-        uses: shivammathur/setup-php@3eda58347216592f618bb1dff277810b6698e4ca # v2.19.1
+        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
         with:
           php-version: 8.1
           extensions: yaml

--- a/action.yml
+++ b/action.yml
@@ -84,12 +84,12 @@ runs:
         echo "fetch-depth=$FETCH_DEPTH" >> "$GITHUB_OUTPUT"
 
     - name: Checkout code
-      uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2.4.2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       with:
         fetch-depth: ${{ steps.set-fetch-depth.outputs.fetch-depth }}
 
     - name: Install PHP
-      uses: shivammathur/setup-php@3eda58347216592f618bb1dff277810b6698e4ca # v2.19.1
+      uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
       with:
         php-version: '8.1'
         extensions: yaml


### PR DESCRIPTION
Updated dependencies to avoid deprecated `save-state` and `set-output`
These versions all use `@actions/core` `v1.10.0` or greater as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Issue
- https://github.com/silverstripe/.github/issues/26