### PR TITLE
DEP Use deps that use node16+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Install PHP
         uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         echo "fetch-depth=$FETCH_DEPTH" >> "$GITHUB_OUTPUT"
 
     - name: Checkout code
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         fetch-depth: ${{ steps.set-fetch-depth.outputs.fetch-depth }}
 


### PR DESCRIPTION
For dependencies on a new major release, the only breaking change listed was swapping node version. We shouldn't experience any issues using the new versions.

Also, note that the version of `shivammathur/setup-php` we're using already uses node 16.

# Issue
- https://github.com/silverstripe/gha-ci/issues/50