### PR TITLE
ENH Add behat-extension to consts

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -342,6 +342,7 @@ const INSTALLER_TO_REPO_MINOR_VERSIONS = [
         'silverstripe-advancedworkflow' => '5.9',
         'silverstripe-akismet' => '4.5',
         'silverstripe-auditor' => '2.6',
+        'silverstripe-behat-extension' => '4.11',
         'silverstripe-blog' => '3.12',
         'silverstripe-ckan-registry' => '1.7',
         'silverstripe-comments' => '3.10',


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-behat-extension/issues/224

This is done so that this [PR](https://github.com/silverstripe/silverstripe-behat-extension/pull/226) with use installer 4.13 when it's re-run