### PR TITLE
MNT Add new repo so installer isn't included

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -97,6 +97,7 @@ const NO_INSTALLER_UNLOCKSTEPPED_REPOS = [
     'api.silverstripe.org',
     'cow',
     'silverstripe-config',
+    'markdown-php-codesniffer',
 ];
 
 const CMS_TO_REPO_MAJOR_VERSIONS = [


### PR DESCRIPTION
Without this, installer is added by default and I think that's why the CI builds are failing.

## Issue
- https://github.com/silverstripe/developer-docs/issues/11