### PR TITLE
MNT Add MariaDB support

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -41,6 +41,7 @@ const DB_MYSQL_57 = 'mysql57';
 const DB_MYSQL_57_PDO = 'mysql57pdo';
 const DB_MYSQL_80 = 'mysql80';
 const DB_PGSQL = 'pgsql';
+const DB_MARIADB = 'mariadb';
 
 // Used when determining the version of installer to used. Intentionally doesn't include recipes
 const LOCKSTEPPED_REPOS = [

--- a/job_creator.php
+++ b/job_creator.php
@@ -348,6 +348,7 @@ class JobCreator
         } else {
             $matrix['include'][] = $this->createJob(0, [
                 'composer_args' => '--prefer-lowest',
+                'db' => DB_MYSQL_57,
                 'phpunit' => true,
                 'phpunit_suite' => $suite,
             ]);
@@ -369,7 +370,7 @@ class JobCreator
                 ]);
             } elseif ($this->getCmsMajor() === '5') {
                 $matrix['include'][] = $this->createJob(0, [
-                    'db' => DB_MYSQL_57,
+                    'db' => DB_MARIADB,
                     'phpunit' => true,
                     'phpunit_suite' => $suite,
                 ]);

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -264,7 +264,7 @@ class JobCreatorTest extends TestCase
                     [
                         'installer_version' => '5.x-dev',
                         'php' => '8.1',
-                        'db' => DB_MYSQL_57,
+                        'db' => DB_MARIADB,
                         'composer_require_extra' => '',
                         'composer_args' => '',
                         'name_suffix' => '',
@@ -276,7 +276,7 @@ class JobCreatorTest extends TestCase
                         'endtoend_suite' => 'root',
                         'endtoend_config' => '',
                         'js' => 'false',
-                        'name' => '8.1 mysql57 phpunit all',
+                        'name' => '8.1 mariadb phpunit all',
                     ],
                     [
                         'installer_version' => '5.x-dev',
@@ -771,7 +771,7 @@ class JobCreatorTest extends TestCase
                 '5.x-dev',
                 [
                     '8.1 prf-low mysql57 phpunit all',
-                    '8.1 mysql57 phpunit all',
+                    '8.1 mariadb phpunit all',
                     '8.2 mysql80 phpunit all'
                 ]
             ],
@@ -781,7 +781,7 @@ class JobCreatorTest extends TestCase
                 '5.x-dev',
                 [
                     '8.1 prf-low mysql57 phpunit all',
-                    '8.1 mysql57 phpunit all',
+                    '8.1 mariadb phpunit all',
                     '8.2 mysql80 phpunit all'
                 ]
             ],
@@ -791,7 +791,7 @@ class JobCreatorTest extends TestCase
                 '5.x-dev',
                 [
                     '8.1 prf-low mysql57 phpunit all',
-                    '8.1 mysql57 phpunit all',
+                    '8.1 mariadb phpunit all',
                     '8.2 mysql80 phpunit all'
                 ]
             ],


### PR DESCRIPTION
## Description
- Add new constant `DB_MARIADB`;
- Updated tests
- Add `DB_MYSQL_57 ` only for `--prefer-lowest`

#### Note:
I'm not sure should we replace all MySQL versions with MariaDB.

## Parent issue
- https://github.com/silverstripe/gha-generate-matrix/issues/69