### PR TITLE
ENH Don't include installer if it's not needed

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -99,12 +99,7 @@ const NO_INSTALLER_LOCKSTEPPED_REPOS = [
 ];
 
 const NO_INSTALLER_UNLOCKSTEPPED_REPOS = [
-    'vendor-plugin',
-    'recipe-plugin',
-    'api.silverstripe.org',
-    'cow',
     'silverstripe-config',
-    'markdown-php-codesniffer',
 ];
 
 const CMS_TO_REPO_MAJOR_VERSIONS = [

--- a/job_creator.php
+++ b/job_creator.php
@@ -56,9 +56,20 @@ class JobCreator
                 }
             }
         }
-        // has a lockstepped .x-dev requirement in composer.json
         if (file_exists($this->composerJsonPath)) {
             $json = json_decode(file_get_contents($this->composerJsonPath));
+            // We shouldn't try to infer the installer version for regular repositories
+            // that weren't already detected via the const-based logic above
+            $silverstripeRepoTypes = [
+                'silverstripe-vendormodule',
+                'silverstripe-module',
+                'silverstripe-recipe',
+                'silverstripe-theme',
+            ];
+            if (!isset($json->type) || !in_array($json->type, $silverstripeRepoTypes)) {
+                return '';
+            }
+            // has a lockstepped .x-dev requirement in composer.json
             foreach (LOCKSTEPPED_REPOS as $lockedSteppedRepo) {
                 $composerRepo = 'silverstripe/' . str_replace('silverstripe-', '', $lockedSteppedRepo);
                 if (isset($json->require->{$composerRepo})) {


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Whenever we add a new repository that _isn't_ a module/recipe/theme, we have to update a constant in order to tell the matrix generator not to add installer for it.

Instead of doing that, the generator just shouldn't try to add installer for those. Anything that isn't a recipe, a module, or a theme but which needs installer for its tests to run should explicitly add installer as a dev dependency.

I'm making this change instead of adding the new standards repo to the const.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/.github/issues/171

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] CI is green
