### PR TITLE
FIX Ensure recipes get databases set up

### DIFF
--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -16,6 +16,7 @@ class JobCreatorTest extends TestCase
     ): void {
         $creator = new JobCreator();
         $creator->githubRepository = $githubRepository;
+        $creator->repoName = explode('/', $githubRepository)[1];
         $creator->branch = $branch;
         $actual = $creator->createJob($phpIndex, $opts);
         foreach ($expected as $key => $expectedVal) {
@@ -74,6 +75,7 @@ class JobCreatorTest extends TestCase
     ): void {
         $creator = new JobCreator();
         $creator->githubRepository = $githubRepository;
+        $creator->repoName = explode('/', $githubRepository)[1];
         $creator->branch = $branch;
         $actual = $creator->getInstallerVersion();
         $this->assertSame($expected, $actual);


### PR DESCRIPTION
In https://github.com/silverstripe/gha-generate-matrix/pull/77 I forgot that recipes don't install installer - so we need to make sure that for modules in the `NO_INSTALLER_LOCKSTEPPED_REPOS` constant we are also allowing full setup.

See https://github.com/silverstripe/gha-ci/issues/97#issuecomment-1913790067 - only the recipe runs are failing.

## Issue
- https://github.com/silverstripe/gha-ci/issues/97