### PR TITLE
Pulls/1.12/fix it properly this time

### DIFF
--- a/job_creator.php
+++ b/job_creator.php
@@ -131,7 +131,8 @@ class JobCreator
             'endtoend_suite' => 'root',
             'endtoend_config' => '',
             'js' => false,
-            'needs_full_setup' => $this->installerVersion !== '' && !in_array($this->repoName, NO_INSTALLER_LOCKSTEPPED_REPOS),
+            // Needs full setup if installerVersion is set, OR this is one of the no-installer lockstepped repos
+            'needs_full_setup' => $this->installerVersion !== '' || in_array($this->repoName, NO_INSTALLER_LOCKSTEPPED_REPOS),
         ];
         return array_merge($default, $opts);
     }


### PR DESCRIPTION
I screwed up the logic for setting `needs_full_setup` again - this time I've added a comment to make it really clear what the logic is meant to be.

- If there is an installer version, it needs full setup.
- If there is no installer version, but this repo is in the `NO_INSTALLER_LOCKSTEPPED_REPOS` const, it needs full setup.
- Everything else doesn't need it.

## Issues
- https://github.com/silverstripe/gha-ci/issues/97