### PR TITLE
FIX Use installer for silverstripe/serve and silverstripe/behat-exten…

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -102,6 +102,12 @@ const NO_INSTALLER_UNLOCKSTEPPED_REPOS = [
     'silverstripe-config',
 ];
 
+// Repositories that either don't have a composer type or have a weird composer type, though we still want installer
+const FORCE_INSTALLER_UNLOCKEDSTEPPED_REPOS = [
+    'silverstripe-behat-extension',
+    'silverstripe-serve',
+];
+
 const CMS_TO_REPO_MAJOR_VERSIONS = [
     '4' => [
         'recipe-authoring-tools' => '1',

--- a/job_creator.php
+++ b/job_creator.php
@@ -68,7 +68,9 @@ class JobCreator
                 'silverstripe-recipe',
                 'silverstripe-theme',
             ];
-            if (!isset($json->type) || !in_array($json->type, $silverstripeRepoTypes)) {
+            if ((!isset($json->type) || !in_array($json->type, $silverstripeRepoTypes)
+                && !in_array($this->repoName, FORCE_INSTALLER_UNLOCKEDSTEPPED_REPOS)
+            )) {
                 return '';
             }
             // has a lockstepped .x-dev requirement in composer.json

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -146,6 +146,9 @@ class JobCreatorTest extends TestCase
             ['myaccount/silverstripe-html5', '2.3', '4.10.x-dev'],
             ['myaccount/silverstripe-html5', '2.4', '4.11.x-dev'],
             ['myaccount/silverstripe-html5', 'burger', $currentMinor],
+            // force installer unlockedstepped repo
+            ['myaccount/silverstripe-serve', '2', $nextMinor],
+            ['myaccount/silverstripe-behat-extension', '2', $nextMinor],
         ];
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/188

silverstripe/serve and silverstripe/behat-extension used to get silverstripe/installer installed, now they don't and their CI stopped working
