### PR TITLE
FIX Do not use recipe-plugin or vendor-plugin to work out cms major

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -139,7 +139,6 @@ const CMS_TO_REPO_MAJOR_VERSIONS = [
         'recipe-core' => '5',
         'recipe-form-building' => '2',
         'recipe-kitchen-sink' => '5',
-        'recipe-plugin' => '2',
         'recipe-reporting-tools' => '2',
         'recipe-services' => '2',
         'recipe-testing' => '3',
@@ -165,7 +164,6 @@ const CMS_TO_REPO_MAJOR_VERSIONS = [
         'silverstripe-testsession' => '3',
         'silverstripe-versioned' => '2',
         'silverstripe-versioned-admin' => '2',
-        'vendor-plugin' => '2',
     ],
     '6' => [
         'MinkFacebookWebDriver' => '3',
@@ -178,7 +176,6 @@ const CMS_TO_REPO_MAJOR_VERSIONS = [
         'recipe-core' => '6',
         'recipe-form-building' => '3',
         'recipe-kitchen-sink' => '6',
-        'recipe-plugin' => '3',
         'recipe-reporting-tools' => '3',
         'recipe-services' => '3',
         'recipe-testing' => '4',
@@ -204,7 +201,6 @@ const CMS_TO_REPO_MAJOR_VERSIONS = [
         'silverstripe-testsession' => '4',
         'silverstripe-versioned' => '3',
         'silverstripe-versioned-admin' => '3',
-        'vendor-plugin' => '3',
     ],
 ];
 

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -985,6 +985,9 @@ class JobCreatorTest extends TestCase
             ['myaccount/silverstripe-somemodule', '4', ['silverstripe/framework' => '^6'], 'package', ''],
             ['myaccount/silverstripe-somemodule', '4', ['silverstripe/framework' => '^6'], '', ''],
             ['myaccount/silverstripe-somemodule', '4', [], '', ''],
+            // // recipe-plugin and vendor-plugin do not override framework
+            ['myaccount/silverstripe-admin', 'mybranch', ['silverstripe/recipe-plugin' => '^2', 'silverstripe/framework' => '^6'], 'silverstripe-vendormodule', '6.x-dev'],
+            ['myaccount/silverstripe-admin', 'mybranch', ['silverstripe/vendor-plugin' => '^2', 'silverstripe/framework' => '^6'], 'silverstripe-vendormodule', '6.x-dev'],
         ];
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/199

recipe-plugin and vendor-plugin ^2 both work in CMS 5 + 6, so cannot be used to determine dynamically work the CMS major version of installer any more.

It caused 5.x-dev to be used instead of 6.x-dev on https://github.com/tractorcow-farm/silverstripe-fluent/actions/runs/8011520958/job/21884953244?pr=827

Note the bit in the release process where we update this is from involves copying .cow.pat.json and running `php hardcoded.php` - this is used to add to the `INSTALLER_TO_REPO_MINOR_VERSIONS` const. vendor-plugin and recipe-plugin will still appear for this in this and that's fine

However that isn't used to workout the CMS major version of installer to use in dynamic e.g. major dev branch with no minor branches, instead it's harcoded version out which version of installer to use for a specific module minor branch. This is different from the dynamic approach which is being disabled in this PR