### PR TITLE
FIX Remove duplicate jobs

### DIFF
--- a/job_creator.php
+++ b/job_creator.php
@@ -706,6 +706,10 @@ class JobCreator
             $matrix['include'][$i]['name'] = implode(' ', $name);
         }
 
+        // ensure there are no duplicate jobs
+        $uniqueSerializedJobs = array_unique(array_map('serialize', $matrix['include']));
+        $matrix['include'] = array_values(array_map('unserialize', $uniqueSerializedJobs));
+
         // output json, keep it on a single line so do not use pretty print
         $json = json_encode($matrix, JSON_UNESCAPED_SLASHES);
         // Remove indents


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/323

Artifacts were unable to be created because on some builds we're creating 2 duplicates builds, usually due to one of them being defined in yml in extra_jobs and the other one just one just being automatically created in the generated matrix.

Rather than find all the duplicate jobs, it's easier to just remove them from the matrix in a central place