### PR TITLE
FIX Use installer 5.3 with graphql 5.2

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -417,7 +417,11 @@ const INSTALLER_TO_REPO_MINOR_VERSIONS = [
         'silverstripe-environmentcheck' => '3.0',
         'silverstripe-externallinks' => '3.2',
         'silverstripe-fluent' => '7.1',
-        'silverstripe-graphql' => '5.2',
+        // GraphQL is commented out here to ensure that it's installed using
+        // installer 5.3, instead of installer 5.2
+        // This is done because otherwise an elemental behat test will fail because
+        // it needs a fix which is in framework 5.3
+        // 'silverstripe-graphql' => '5.2',
         'silverstripe-gridfield-bulk-editing-tools' => '4.0',
         'silverstripe-gridfieldextensions' => '4.0',
         'silverstripe-gridfieldqueuedexport' => '3.2',

--- a/job_creator.php
+++ b/job_creator.php
@@ -56,7 +56,8 @@ class JobCreator
             foreach (INSTALLER_TO_REPO_MINOR_VERSIONS[$installerVersion] as $_repo => $_repoVersions) {
                 $repoVersions = is_array($_repoVersions) ? $_repoVersions : [$_repoVersions];
                 foreach ($repoVersions as $repoVersion) {
-                    if ($this->repoName === $_repo && $repoVersion === preg_replace('#-release$#', '', $this->branch)) {
+                    $thisBranch = preg_replace('#-release$#', '', $this->branch);
+                    if ($this->repoName === $_repo && $thisBranch === $repoVersion) {
                         return $installerVersion . '.x-dev';
                     }
                 }
@@ -374,7 +375,7 @@ class JobCreator
         // Fallback to using a CMS major based on the version of PHP in composer.json
         $json = $this->getComposerJsonContent();
         if ($json) {
-            $php = $json->require->php ?? null;
+            $php = $json->require->php ?? '';
             $php = str_replace('^', '', $php);
             $cmsMajors = array_keys(MetaData::PHP_VERSIONS_FOR_CMS_RELEASES);
             $cmsMajors = array_filter($cmsMajors, fn($v) => !str_contains($v, '.'));

--- a/tests/JobCreatorTest.php
+++ b/tests/JobCreatorTest.php
@@ -1144,6 +1144,103 @@ class JobCreatorTest extends TestCase
                     ],
                 ]
             ],
+            // test for graphql 5.2 which is used in both installer 5.3 and installer 5.2
+            // it should use installer 5.3.x-dev
+            [
+                implode("\n", [
+                    $this->getGenericYml(),
+                    <<<EOT
+                    github_repository: 'myaccount/silverstripe-graphql'
+                    github_my_ref: '5.2'
+                    parent_branch: ''
+                    EOT
+                ]),
+                false,
+                false,
+                false,
+                [
+                    [
+                        'installer_version' => '5.3.x-dev',
+                        'php' => '8.1',
+                        'db' => DB_MYSQL_57,
+                        'composer_require_extra' => '',
+                        'composer_args' => '--prefer-lowest',
+                        'name_suffix' => '',
+                        'phpunit' => 'true',
+                        'phpunit_suite' => 'all',
+                        'phplinting' => 'false',
+                        'phpcoverage' => 'false',
+                        'endtoend' => 'false',
+                        'endtoend_suite' => 'root',
+                        'endtoend_config' => '',
+                        'endtoend_tags' => '',
+                        'js' => 'false',
+                        'doclinting' => 'false',
+                        'needs_full_setup' => 'true',
+                        'name' => '8.1 prf-low mysql57 phpunit all',
+                    ],
+                    [
+                        'installer_version' => '5.3.x-dev',
+                        'php' => '8.2',
+                        'db' => DB_MARIADB,
+                        'composer_require_extra' => '',
+                        'composer_args' => '',
+                        'name_suffix' => '',
+                        'phpunit' => 'true',
+                        'phpunit_suite' => 'all',
+                        'phplinting' => 'false',
+                        'phpcoverage' => 'false',
+                        'endtoend' => 'false',
+                        'endtoend_suite' => 'root',
+                        'endtoend_config' => '',
+                        'endtoend_tags' => '',
+                        'js' => 'false',
+                        'doclinting' => 'false',
+                        'needs_full_setup' => 'true',
+                        'name' => '8.2 mariadb phpunit all',
+                    ],
+                    [
+                        'installer_version' => '5.3.x-dev',
+                        'php' => '8.3',
+                        'db' => DB_MYSQL_80,
+                        'composer_require_extra' => '',
+                        'composer_args' => '',
+                        'name_suffix' => '',
+                        'phpunit' => 'true',
+                        'phpunit_suite' => 'all',
+                        'phplinting' => 'false',
+                        'phpcoverage' => 'false',
+                        'endtoend' => 'false',
+                        'endtoend_suite' => 'root',
+                        'endtoend_config' => '',
+                        'endtoend_tags' => '',
+                        'js' => 'false',
+                        'doclinting' => 'false',
+                        'needs_full_setup' => 'true',
+                        'name' => '8.3 mysql80 phpunit all',
+                    ],
+                    [
+                        'installer_version' => '5.3.x-dev',
+                        'php' => '8.3',
+                        'db' => DB_MYSQL_84,
+                        'composer_require_extra' => '',
+                        'composer_args' => '',
+                        'name_suffix' => '',
+                        'phpunit' => 'true',
+                        'phpunit_suite' => 'all',
+                        'phplinting' => 'false',
+                        'phpcoverage' => 'false',
+                        'endtoend' => 'false',
+                        'endtoend_suite' => 'root',
+                        'endtoend_config' => '',
+                        'endtoend_tags' => '',
+                        'js' => 'false',
+                        'doclinting' => 'false',
+                        'needs_full_setup' => 'true',
+                        'name' => '8.3 mysql84 phpunit all',
+                    ],
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes issue where elemental 5.3.4 is being used because framework 5.2 is being used as installer 5.2 is the lowest version [compatible](https://github.com/silverstripe/gha-generate-matrix/blob/1/consts.php#L420) with graphql version in gha-generate-matrix causing CI to [fail](https://github.com/silverstripe/silverstripe-graphql/actions/runs/12761341352/job/35612312845)

Instead we need elemental [5.3.5](https://github.com/silverstripe/silverstripe-elemental/releases/tag/5.3.5) which requires framework 5.3

We need to use framework 5.3 in order to get this [fix](https://github.com/silverstripe/silverstripe-elemental/pull/1304)

After multiple attempts at doing this with composer, e.g. [this](https://github.com/silverstripe/silverstripe-graphql/pull/622), it seems like the only way to actually do this is to hardcode it straight into gha-generate-matrix