### PR TITLE
FIX Remove mapping for CMS 5.1 to elemental userforms

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -357,7 +357,6 @@ const INSTALLER_TO_REPO_MINOR_VERSIONS = [
         'silverstripe-elemental' => '5.1',
         'silverstripe-elemental-bannerblock' => '3.1',
         'silverstripe-elemental-fileblock' => '3.1',
-        'silverstripe-elemental-userforms' => '4.1',
         'silverstripe-environmentcheck' => '3.0',
         'silverstripe-externallinks' => '3.1',
         'silverstripe-fluent' => '7.0',


### PR DESCRIPTION
While this mapping is technically correct, it's resulting in php linting failing, because installer 5.1 is installed which was before generic typing was added to the lists. This makes PHPStan think the type hint should resolve to `iterable<SilverStripe\Taxonomy\TaxonomyTerm>&SilverStripe\ORM\HasManyList` but it really should be `SilverStripe\ORM\HasManyList<SilverStripe\Taxonomy\TaxonomyTerm>`.

Fixes https://github.com/dnadesign/silverstripe-elemental-userforms/actions/runs/14457656635

```text
@method annotation 'HasManyList<SubmittedForm> Submissions()' should be 'HasManyList<SubmittedForm> Submissions()'.
```

## Issue
- https://github.com/silverstripe/.github/issues/389