### PR TITLE
DEP Use a tagged version of supported-modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "silverstripe/supported-modules": "dev-main"
+        "silverstripe/supported-modules": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6"


### PR DESCRIPTION
This gives us stability so that when we change the API or update const values we don't have things breaking all over the place.

In this case specifically it means CMS 4 modules can keep running CI without anything breaking.
Nothing has to change _immediately_ for CMS 6 modules, but they'll have to update to `^2` eventually.

## Issue

- https://github.com/silverstripe/.github/issues/407